### PR TITLE
simplified form and renamed fields

### DIFF
--- a/azlibrary_react/src/components/container/Search.js
+++ b/azlibrary_react/src/components/container/Search.js
@@ -27,54 +27,54 @@ export default function Search({ searchUrl, searchParams, setSearchParams }) {
         <div>
             <div className=" bg-cool-gray rounded mb-4 p-3 shadow">
 
-                <div className="searchHeader text-center">Search Collections</div>
+                <div className="searchHeader text-center">Search Publications</div>
 
                 <form autoComplete="off">
 
+                    <div className="form-row">
+                            <label htmlFor="keyword">Keyword</label>
+                            <input type="text" className="form-control form-control-sm" id="keyword" name="keyword" value={searchParams.keyword ?? ""} onChange={handleChange} />
+                    </div>
+                    
                     <SelectCollectionGroup id="collection_group" className="form-control form-control-sm" fieldValue={searchParams.collection_group ?? ""} onChange={handleChange} />
-
+                    
                     <div className="form-row">
-                        <label htmlFor="text">Full-Text Search</label>
-                        <input type="text" className="form-control form-control-sm" id="text" name="text" value={searchParams.text ?? ""} onChange={handleChange} />
-                    </div>
-
-                    <div className="form-row">
-                        <label htmlFor="year">Year</label>
-                    </div>
-
-                    <div className="form-row">
-                        <div className="col p-0">
-                            <input type="text" className="form-control form-control-sm" id="year" name="year" min='0' value={searchParams.year ?? ""} onChange={handleChange} />
-                        </div>
-                        <div className="text-center">
-                            -
-                        </div>
-                        <div className="col p-0">
-                            <input type="text" className="form-control form-control-sm" id="endYear" name="endYear" disabled />
-                        </div>
-                    </div>
-
-                    <div className="form-row">
-                        <label htmlFor="title">Title</label>
-                        <input type="text" className="form-control form-control-sm" id="title" name="title" value={searchParams.title ?? ""} onChange={handleChange} />
-                    </div>
-
-                    <div className="form-row">
-                        <label htmlFor="author">Author</label>
-                        <input type="text" className="form-control form-control-sm" id="author" name="author" value={searchParams.author ?? ""} onChange={handleChange} />
+                            <label htmlFor="title">Title</label>
+                            <input type="text" className="form-control form-control-sm" id="title" name="title" value={searchParams.title ?? ""} onChange={handleChange} />
                     </div>
 
                     <div className="collapse" id="advancedSearch">
-
+                       
                         <div className="form-row">
-                            <label htmlFor="keyword">Keyword</label>
-                            <input type="text" className="form-control form-control-sm" id="keyword" name="keyword" value={searchParams.keyword ?? ""} onChange={handleChange} />
+                            <label htmlFor="text">Full-Text Search</label>
+                            <input type="text" className="form-control form-control-sm" id="text" name="text" value={searchParams.text ?? ""} onChange={handleChange} />
+                        </div>
+                        
+                        <div className="form-row">
+                            <label htmlFor="year">Year</label>
                         </div>
 
                         <div className="form-row">
-                            <label htmlFor="keyword">Series</label>
+                            <div className="col p-0">
+                                <input type="text" className="form-control form-control-sm" id="year" name="year" min='0' value={searchParams.year ?? ""} onChange={handleChange} />
+                            </div>
+                            <div className="text-center">
+                                -
+                            </div>
+                            <div className="col p-0">
+                                <input type="text" className="form-control form-control-sm" id="endYear" name="endYear" disabled />
+                            </div>
+                        </div>
+
+                        <div className="form-row">
+                            <label htmlFor="author">Author</label>
+                            <input type="text" className="form-control form-control-sm" id="author" name="author" value={searchParams.author ?? ""} onChange={handleChange} />
+                        </div>
+                        
+                        <div className="form-row">
+                            <label htmlFor="series">Series</label>
                             <input type="text" className="form-control form-control-sm" id="series" name="series" value={searchParams.series ?? ""} onChange={handleChange} />
-                        </div>
+                        </div>                                                                   
 
                         {/* <div className="form-row">
                             <label htmlFor="limit">Results Per Page</label>
@@ -101,7 +101,7 @@ export default function Search({ searchUrl, searchParams, setSearchParams }) {
 
                     <div>
                         <button className="btn btn-link my-2" type="button" data-toggle="collapse" data-target="#advancedSearch" aria-expanded="false" aria-controls="advancedSearch" onClick={() => setAdvancedToggle(!advancedToggle)} >
-                            {advancedToggle ? "Basic Search" : "More Search Options"} 
+                            {advancedToggle ? "Basic Search" : "Click Here For More Search Options"} 
                         </button>
                     </div>
 

--- a/azlibrary_react/src/components/container/SelectCollectionGroup.js
+++ b/azlibrary_react/src/components/container/SelectCollectionGroup.js
@@ -31,12 +31,12 @@ export default function SelectCollectionGroup({ id, className, fieldValue, onCha
 
     return (
         <div className="form-row">
-            <label htmlFor={id}>Collection Group</label>
+            <label htmlFor={id}>Collection</label>
             <select className={className} id={id} name={id} onChange={onChange} value={fieldValue}>
                 <option value="">--All Collections--</option>
                 {
                     groups?.map(group =>
-                        <option key={group.id} value={group.abbrv}>{group.abbrv} - {group.name}</option>
+                        <option key={group.id} value={group.abbrv}>{group.name}</option>
                     )
                 }
             </select>

--- a/azlibrary_react/src/pages/Layout.js
+++ b/azlibrary_react/src/pages/Layout.js
@@ -61,7 +61,7 @@ const Layout = () => {
                 </nav>
 
                 <div className="alert alert-success alert-dismissible fade show text-center  rounded py-4" role="alert">
-                    The AZGS Library website is the replacement for the AZGS Document Repository. This site is still under development. Please visit our <a className="alert-link" href="https://github.com/azgs/azlibrary_react" target="_blank" rel="noopener noreferrer" >GitHub</a> for additional information and support.
+                    The AZGS Library website is the replacement for the AZGS Document Repository. This site is still under development. Please visit our <a className="alert-link" href="https://github.com/azgs/azlibrary_react" target="_blank" rel="noopener noreferrer" >GitHub</a> for additional information and support. All AZGS publications can also be accessed from the <a className="alert-link" href="https://repository.arizona.edu/handle/10150/628301" target="_blank" rel="noopener noreferrer" >University of Arizona Campus Repository</a>.
                     <button type="button" className="close" data-dismiss="alert" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>


### PR DESCRIPTION
1. Reduced the "Basic Search" to just Keyword (blegh), Collection, and Title
2. Changed Advanced Search message to "CLICK HERE FOR MORE SEARCH OPTIONS"
3. Renamed header from Search Collections to Search Publications
4. Removed Abbreviations from Collection_Group dropdown
5. Changed Collection_Group to just Collection
6. Added link to UA Library in top banner.